### PR TITLE
OPEN-185: Removed set start_date to first occurence of rrule.

### DIFF
--- a/resources/assets/js/components/CalendarEditor.vue
+++ b/resources/assets/js/components/CalendarEditor.vue
@@ -218,23 +218,9 @@
                 this.$root.fetchVersion(true)
             },
             save() {
-                // Set start_date to first occurrence of rrule
-                this.cal.events.forEach(e => {
-                    const limitedRule = keepRuleWithin(e);
-                    const date = rruleToStarts(limitedRule + ';COUNT=1')[0];
-                    if (date) {
-                        date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
-                        if (e.start_date.slice(0, 10) !== date.toJSON().slice(0, 10)) {
-                            e.start_date = date.toJSON().slice(0, 10) + e.start_date.slice(10);
-                            e.end_date = date.toJSON().slice(0, 10) + e.end_date.slice(10)
-                        }
-                    }
-                });
-
                 if (this.disabled) {
                     return console.warn('Expected valid calendar')
                 }
-
                 Hub.$emit('createCalendar', this.cal, true)
             },
             saveLabel() {


### PR DESCRIPTION
## **!FAILED TEST Tests\Console\FetchRecreatexTest::testCalendarIsImported**
Ik heb nog lokaal nog nooit recreatex kunnen 'fetchen'.

**Ik kan de impact op vesta en onze eigen backend moeilijk inschatten**

Oude versie:
{ "id": 275, "rrule": "BYDAY=WE;FREQ=WEEKLY", "start_date": "2016-01-06 09:00:00", "end_date": "2016-01-06 17:00:00", "calendar_id": 205, "created_at": "2018-02-01 13:43:01", "updated_at": "2018-02-01 13:43:01", "label": "1", "until": "2017-01-02" }

Nieuw, na verwijderen van die conversie:
{ "id": 285, "rrule": "BYDAY=WE;FREQ=WEEKLY", "start_date": "2016-01-01 09:00:00", "end_date": "2016-01-01 17:00:00", "calendar_id": 205, "created_at": "2018-02-01 13:57:47", "updated_at": "2018-02-01 13:57:47", "label": "1", "until": "2017-01-02" } 