### PR TITLE
OPEN-219 send soap request to empty Vesta openinghours.

### DIFF
--- a/app/Jobs/DeleteVestaOpeninghours.php
+++ b/app/Jobs/DeleteVestaOpeninghours.php
@@ -65,6 +65,7 @@ class DeleteVestaOpeninghours extends BaseJob implements ShouldQueue
     public function handle()
     {
         error_log('deleting vesta openinghours');
+        \Log::info('deleting vesta openinghours');
 
         $serviceCollection = Service::where('id', $this->serviceId)
             ->where('source', 'vesta')

--- a/app/Jobs/DeleteVestaOpeninghours.php
+++ b/app/Jobs/DeleteVestaOpeninghours.php
@@ -74,7 +74,7 @@ class DeleteVestaOpeninghours extends BaseJob implements ShouldQueue
         $service = $serviceCollection->first();
 
         if ( ! $service->draft) {
-            $this->letsFail('service was not draft');
+            $this->letsFail('Service was not draft.');
         }
 
         try {

--- a/app/Jobs/DeleteVestaOpeninghours.php
+++ b/app/Jobs/DeleteVestaOpeninghours.php
@@ -5,6 +5,7 @@ namespace App\Jobs;
 use App\Models\Service;
 use App\Services\VestaService;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Log;
 
 /**
  * This JOB will delete openinghours in vesta for inactive services.
@@ -64,9 +65,6 @@ class DeleteVestaOpeninghours extends BaseJob implements ShouldQueue
      */
     public function handle()
     {
-        error_log('deleting vesta openinghours');
-        \Log::info('deleting vesta openinghours');
-
         $serviceCollection = Service::where('id', $this->serviceId)
             ->where('source', 'vesta')
             ->where('identifier', $this->vestaUid);
@@ -97,9 +95,9 @@ class DeleteVestaOpeninghours extends BaseJob implements ShouldQueue
         if ( ! $synced) {
             $this->letsFail('Not able to send the data to VESTA.');
         }
-        \Log::info('Request to empty openinghours for (' . $service->id . ') ' . $service->label . ' VESTA UID ' .
+        Log::info('Request to empty openinghours for (' . $service->id . ') ' . $service->label . ' VESTA UID ' .
             $service->identifier . ' is send to VESTA.');
-        \Log::info('Service (' . $service->id . ') ' . $service->label . ' with UID ' .
+        Log::info('Service (' . $service->id . ') ' . $service->label . ' with UID ' .
             $service->identifier . ' is sync with VESTA.');
 
         $this->letsFinish();

--- a/app/Jobs/DeleteVestaOpeninghours.php
+++ b/app/Jobs/DeleteVestaOpeninghours.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Service;
+use App\Services\VestaService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+/**
+ * This JOB will delete openinghours in vesta for inactive services.
+ *
+ * Job will be triggered by the OBSERVERS on models to update by alteration on
+ * MODEL OR by the COMMAND DeleteSchedulesInVesta to keep texts for next 3
+ * months up to date
+ *
+ * Currently all output is in Dutch nl-BE
+ */
+class DeleteVestaOpeninghours extends BaseJob implements ShouldQueue
+{
+
+    /**
+     * The UID of the service in VESTA
+     *
+     * @var string
+     */
+    private $vestaUid;
+
+    /**
+     * The ID of the service
+     *
+     * @var int
+     */
+    private $serviceId;
+
+    /**
+     * @var boolean
+     */
+    protected $test;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct($vestaUid, $serviceId, $test = false)
+    {
+        parent::__construct();
+        $this->vestaUid = $vestaUid;
+        $this->serviceId = $serviceId;
+        $this->test = $test;
+
+        $this->extModelClass = Service::class;
+        $this->extId = $serviceId;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * Send request to VESTA to delete openinghours for inactive services.
+     * Checks:
+     * - the service must not be active (draft = 0 will fail)
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        error_log('deleting vesta openinghours');
+
+        $serviceCollection = Service::where('id', $this->serviceId)
+            ->where('source', 'vesta')
+            ->where('identifier', $this->vestaUid);
+        if ($serviceCollection->count() != 1) {
+            $this->letsFail('Incompatible with VESTA or uid ' . $this->vestaUid);
+        }
+        $service = $serviceCollection->first();
+
+        if ( ! $service->draft) {
+            $this->letsFail('service was not draft');
+        }
+
+        try {
+            $this->sendToVesta($service);
+        } catch (\Exception $ex) {
+            $this->letsFail($ex->getMessage());
+        }
+    }
+
+    /**
+     * @param string $output
+     */
+    protected function sendToVesta($service)
+    {
+        $vService = app(VestaService::class);
+        $vService->setClient();
+        $synced = $vService->emptyOpeninghours($service->identifier);
+        if ( ! $synced) {
+            $this->letsFail('Not able to send the data to VESTA.');
+        }
+        \Log::info('Request to empty openinghours for (' . $service->id . ') ' . $service->label . ' VESTA UID ' .
+            $service->identifier . ' is send to VESTA.');
+        \Log::info('Service (' . $service->id . ') ' . $service->label . ' with UID ' .
+            $service->identifier . ' is sync with VESTA.');
+
+        $this->letsFinish();
+    }
+}

--- a/app/Jobs/UpdateVestaOpeninghours.php
+++ b/app/Jobs/UpdateVestaOpeninghours.php
@@ -58,8 +58,8 @@ class UpdateVestaOpeninghours extends BaseJob implements ShouldQueue
      * Sync the data for the next 3 months to VESTA
      * Checks:
      * - the service must be active (draft = 1 will fail)
-     * - there is actualy be data to send to VESTA (empty output will fail)
-     * - the data to be send is different from what is already in VESTA (idential will not be send)
+     * - there is actually data to send to VESTA (empty output will fail)
+     * - the data to be send is different from what is already in VESTA (identical will not be send)
      *
      * @return void
      */
@@ -67,6 +67,7 @@ class UpdateVestaOpeninghours extends BaseJob implements ShouldQueue
     {
         $startDate = Carbon::now();
         $endDate = $startDate->copy()->addMonths(1);
+        error_log('updating vesta openinghours');
 
         $serviceCollection = Service::where('id', $this->serviceId)
             ->where('source', 'vesta')

--- a/app/Jobs/UpdateVestaOpeninghours.php
+++ b/app/Jobs/UpdateVestaOpeninghours.php
@@ -7,6 +7,7 @@ use App\Services\RecurringOHService;
 use App\Services\VestaService;
 use Carbon\Carbon;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Log;
 
 /**
  * This JOB will collect the Openinghours data for the next 3 months of a service
@@ -104,9 +105,9 @@ class UpdateVestaOpeninghours extends BaseJob implements ShouldQueue
         if (!$synced) {
             $this->letsFail('Not able to send the data to VESTA.');
         }
-        \Log::info('New data for (' . $service->id . ') ' . $service->label . ' VESTA UID ' .
+        Log::info('New data for (' . $service->id . ') ' . $service->label . ' VESTA UID ' .
             $service->identifier . ' is send to VESTA.');
-        \Log::info('Service (' . $service->id . ') ' . $service->label . ' with UID ' .
+        Log::info('Service (' . $service->id . ') ' . $service->label . ' with UID ' .
             $service->identifier . ' is sync with VESTA.');
 
         $this->letsFinish();

--- a/app/Jobs/UpdateVestaOpeninghours.php
+++ b/app/Jobs/UpdateVestaOpeninghours.php
@@ -68,7 +68,6 @@ class UpdateVestaOpeninghours extends BaseJob implements ShouldQueue
     {
         $startDate = Carbon::now();
         $endDate = $startDate->copy()->addMonths(1);
-        error_log('updating vesta openinghours');
 
         $serviceCollection = Service::where('id', $this->serviceId)
             ->where('source', 'vesta')

--- a/app/Observers/ServiceObserver.php
+++ b/app/Observers/ServiceObserver.php
@@ -3,7 +3,6 @@
 namespace App\Observers;
 
 use App\Models\Service;
-use Illuminate\Support\Facades\Log;
 
 /**
  * Observer on Service Object
@@ -24,7 +23,6 @@ class ServiceObserver
      */
     public function saved(Service $service)
     {
-        Log::info('service observer triggered');
         app('ServiceService')->makeSyncJobsForExternalServices($service, 'update');
     }
 }

--- a/app/Observers/ServiceObserver.php
+++ b/app/Observers/ServiceObserver.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Service;
+
+/**
+ * Observer on Service Object
+ *
+ * These methods will be fired by Eloquent base events.
+ * - When saved we want to sync the new data for the full Openinghours to the external services
+ */
+class ServiceObserver
+{
+    /**
+     * process after entity is saved
+     *
+     * trigger jobs of Openinghours
+     * that will sync new values to external services
+     *
+     * @param  Service $service
+     * @return void
+     */
+    public function saved(Service $service)
+    {
+        app('ServiceService')->makeSyncJobsForExternalServices($service, 'update');
+    }
+}

--- a/app/Observers/ServiceObserver.php
+++ b/app/Observers/ServiceObserver.php
@@ -3,6 +3,7 @@
 namespace App\Observers;
 
 use App\Models\Service;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Observer on Service Object
@@ -23,6 +24,9 @@ class ServiceObserver
      */
     public function saved(Service $service)
     {
+        Log::info('service observer triggered');
+        Log::error('Something is really going wrong.');
+        error_log('service observer triggered');
         app('ServiceService')->makeSyncJobsForExternalServices($service, 'update');
     }
 }

--- a/app/Observers/ServiceObserver.php
+++ b/app/Observers/ServiceObserver.php
@@ -25,8 +25,6 @@ class ServiceObserver
     public function saved(Service $service)
     {
         Log::info('service observer triggered');
-        Log::error('Something is really going wrong.');
-        error_log('service observer triggered');
         app('ServiceService')->makeSyncJobsForExternalServices($service, 'update');
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,9 +5,11 @@ namespace App\Providers;
 use App\Models\Calendar;
 use App\Models\Channel;
 use App\Models\Openinghours;
+use App\Models\Service;
 use App\Observers\CalendarObserver;
 use App\Observers\ChannelObserver;
 use App\Observers\OpeninghoursObserver;
+use App\Observers\ServiceObserver;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -20,6 +22,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         /* OBSERVERS */
+        Service::observe(ServiceObserver::class);
         Calendar::observe(CalendarObserver::class);
         Channel::observe(ChannelObserver::class);
         Openinghours::observe(OpeninghoursObserver::class);
@@ -70,6 +73,11 @@ class AppServiceProvider extends ServiceProvider
         });
 
         /* SERVICES **/
+        $this->app->singleton(\App\Services\ServiceService::class, function ($app) {
+            return \App\Services\ServiceService::getInstance();
+        });
+        $this->app->alias(\App\Services\ServiceService::class, 'ServiceService');
+
         $this->app->singleton(\App\Services\ChannelService::class, function ($app) {
             return \App\Services\ChannelService::getInstance();
         });

--- a/app/Services/ServiceService.php
+++ b/app/Services/ServiceService.php
@@ -2,9 +2,7 @@
 
 namespace App\Services;
 
-use App\Jobs\DeleteLodChannel;
-use App\Jobs\UpdateVestaOpeninghours;
-use App\Models\Channel;
+use App\Jobs\DeleteVestaOpeninghours;
 use App\Models\Service;
 
 /**
@@ -12,6 +10,7 @@ use App\Models\Service;
  */
 class ServiceService
 {
+
     /**
      * Singleton class instance.
      *
@@ -39,7 +38,7 @@ class ServiceService
      */
     public static function getInstance()
     {
-        if (!self::$instance) {
+        if ( ! self::$instance) {
             self::$instance = new self();
         }
         self::$instance->serviceModel = null;
@@ -54,21 +53,18 @@ class ServiceService
      * Make job delete LOD
      *
      * @param  Service $service
+     *
      * @return void
      */
     public function makeSyncJobsForExternalServices(Service $service)
     {
-        error_log('serviceService');
-        error_log($service);
+        // Update VESTA if the service is linked to a VESTA UID
+        if ( ! empty($service) && $service->source == 'vesta' && $service->draft) {
+            $job = new DeleteVestaOpeninghours($service->identifier,
+                $service->id);
+            $this->queueService->addJobToQueue($job, get_class($service),
+                $service->id);
+        }
 
-//        // Update VESTA if the service is linked to a VESTA UID
-//        if (!empty($service) && $service->source == 'vesta') {
-//            $job = new UpdateVestaOpeninghours($service->identifier, $service->id);
-//            $this->queueService->addJobToQueue($job, get_class($service), $service->id);
-//        }
-//
-//        // Remove the LOD repository
-//        $job = new DeleteLodChannel($service->id, $channel->id);
-//        $this->queueService->addJobToQueue($job, get_class($channel), $channel->id);
     }
 }

--- a/app/Services/ServiceService.php
+++ b/app/Services/ServiceService.php
@@ -5,16 +5,17 @@ namespace App\Services;
 use App\Jobs\DeleteLodChannel;
 use App\Jobs\UpdateVestaOpeninghours;
 use App\Models\Channel;
+use App\Models\Service;
 
 /**
- * Internal Business logic Service for Channel
+ * Internal Business logic Service for Service
  */
-class ChannelService
+class ServiceService
 {
     /**
      * Singleton class instance.
      *
-     * @var ChannelService
+     * @var ServiceService
      */
     private static $instance;
 
@@ -34,7 +35,7 @@ class ChannelService
     /**
      * GetInstance for Singleton pattern
      *
-     * @return ChannelService
+     * @return ServiceService
      */
     public static function getInstance()
     {
@@ -52,21 +53,22 @@ class ChannelService
      * Make job for VESTA update when service has a vesta source.
      * Make job delete LOD
      *
-     * @param  Channel $channel
+     * @param  Service $service
      * @return void
      */
-    public function makeSyncJobsForExternalServices(Channel $channel)
+    public function makeSyncJobsForExternalServices(Service $service)
     {
-        $service = $channel->service;
+        error_log('serviceService');
+        error_log($service);
 
-        // Update VESTA if the service is linked to a VESTA UID
-        if (!empty($service) && $service->source == 'vesta') {
-            $job = new UpdateVestaOpeninghours($service->identifier, $service->id);
-            $this->queueService->addJobToQueue($job, get_class($service), $service->id);
-        }
-
-        // Remove the LOD repository
-        $job = new DeleteLodChannel($service->id, $channel->id);
-        $this->queueService->addJobToQueue($job, get_class($channel), $channel->id);
+//        // Update VESTA if the service is linked to a VESTA UID
+//        if (!empty($service) && $service->source == 'vesta') {
+//            $job = new UpdateVestaOpeninghours($service->identifier, $service->id);
+//            $this->queueService->addJobToQueue($job, get_class($service), $service->id);
+//        }
+//
+//        // Remove the LOD repository
+//        $job = new DeleteLodChannel($service->id, $channel->id);
+//        $this->queueService->addJobToQueue($job, get_class($channel), $channel->id);
     }
 }

--- a/app/Services/VestaService.php
+++ b/app/Services/VestaService.php
@@ -164,6 +164,45 @@ class VestaService
     }
 
     /**
+     * Empty Openinghours in VESTA
+     *
+     * Assemble Soap call FillHours
+     * Check response for failing
+     * Return boolean for success
+     *
+     * @param  string $vestaUid
+     * @return boolean
+     */
+    public function emptyOpeninghours($guid)
+    {
+        $client =  $this->getClient();
+        if (!$guid) {
+            throw new \Exception('A guid is required to empty the data in VESTA');
+        }
+        $parameters = $this->getActionParams();
+        $parameters->accountId = new \SoapVar($guid, XSD_STRING, null, null, 'accountId', 'http://schemas.datacontract.org/2004/07/VestaDataMaster.Models');
+        $response = $client->EmptyHours($parameters);
+        if (!isset($response->EmptyHoursResult)) {
+            \Log::error('Something went wrong in VESTA.', [
+                'response' => print_r($response, 1),
+            ]);
+
+            return false;
+        }
+
+        $emptyHoursResult = json_decode($response->EmptyHoursResult);
+        if ($emptyHoursResult !== 1) {
+            \Log::error('Something went wrong while writing the data to VESTA.', [
+                'response' => var_export($response, true),
+            ]);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Get the data out of VESTA
      * Only usefull as doublec heck
      * returns the ves_openingsuren of the
@@ -227,6 +266,10 @@ class VestaService
      */
     public function makeSyncJobsForExternalServices(Openinghours $openinghours, $type)
     {
+        error_log('vestaService');
+        error_log($openinghours);
+        error_log($type);
+
         if (!in_array($type, ['update', 'delete'])) {
             throw new \Exception('Define correct type of sync to external services', 1);
         }

--- a/app/Services/VestaService.php
+++ b/app/Services/VestaService.php
@@ -191,8 +191,6 @@ class VestaService
             return false;
         }
 
-        Log::info('Received response from EmptyHours: ' . var_export($response, true));
-
         $emptyHoursResult = json_decode($response->EmptyHoursResult);
         if ($emptyHoursResult !== 1) {
             Log::error('Something went wrong while writing the data to VESTA.', [

--- a/app/Services/VestaService.php
+++ b/app/Services/VestaService.php
@@ -191,6 +191,10 @@ class VestaService
             return false;
         }
 
+        Log::info('Received response from EmptyHours', [
+            'response' => var_export($response, true),
+        ]);
+
         $emptyHoursResult = json_decode($response->EmptyHoursResult);
         if ($emptyHoursResult !== 1) {
             Log::error('Something went wrong while writing the data to VESTA.', [

--- a/app/Services/VestaService.php
+++ b/app/Services/VestaService.php
@@ -6,7 +6,6 @@ use App\Jobs\DeleteLodOpeninghours;
 use App\Jobs\UpdateLodOpeninghours;
 use App\Jobs\UpdateVestaOpeninghours;
 use App\Models\Openinghours;
-use App\Services\QueueService;
 
 /**
  * This class writes text to the VESTA application based on a certain VESTA UID
@@ -266,10 +265,6 @@ class VestaService
      */
     public function makeSyncJobsForExternalServices(Openinghours $openinghours, $type)
     {
-        error_log('vestaService');
-        error_log($openinghours);
-        error_log($type);
-
         if (!in_array($type, ['update', 'delete'])) {
             throw new \Exception('Define correct type of sync to external services', 1);
         }

--- a/app/Services/VestaService.php
+++ b/app/Services/VestaService.php
@@ -145,7 +145,7 @@ class VestaService
         $parameters->hours = new \SoapVar('<ns2:hours><![CDATA[' . $hours . ']]></ns2:hours>', XSD_ANYXML);
         $response = $client->FillHours($parameters);
         if (!isset($response->FillHoursResult)) {
-            \Log::error('Something went wrong in VESTA.', [
+            Log::error('Something went wrong in VESTA.', [
                 'response' => print_r($response, 1),
             ]);
 
@@ -154,7 +154,7 @@ class VestaService
 
         $fillHoursResult = json_decode($response->FillHoursResult);
         if ($fillHoursResult !== 1) {
-            \Log::error('Something went wrong while writing the data to VESTA.', [
+            Log::error('Something went wrong while writing the data to VESTA.', [
                 'response' => var_export($response, true),
             ]);
 
@@ -191,9 +191,7 @@ class VestaService
             return false;
         }
 
-        Log::info('Received response from EmptyHours', [
-            'response' => var_export($response, true),
-        ]);
+        Log::info('Received response from EmptyHours: ' . var_export($response, true));
 
         $emptyHoursResult = json_decode($response->EmptyHoursResult);
         if ($emptyHoursResult !== 1) {

--- a/app/Services/VestaService.php
+++ b/app/Services/VestaService.php
@@ -6,6 +6,8 @@ use App\Jobs\DeleteLodOpeninghours;
 use App\Jobs\UpdateLodOpeninghours;
 use App\Jobs\UpdateVestaOpeninghours;
 use App\Models\Openinghours;
+use Illuminate\Support\Facades\Log;
+
 
 /**
  * This class writes text to the VESTA application based on a certain VESTA UID
@@ -182,7 +184,7 @@ class VestaService
         $parameters->accountId = new \SoapVar($guid, XSD_STRING, null, null, 'accountId', 'http://schemas.datacontract.org/2004/07/VestaDataMaster.Models');
         $response = $client->EmptyHours($parameters);
         if (!isset($response->EmptyHoursResult)) {
-            \Log::error('Something went wrong in VESTA.', [
+            Log::error('Something went wrong in VESTA.', [
                 'response' => print_r($response, 1),
             ]);
 
@@ -191,7 +193,7 @@ class VestaService
 
         $emptyHoursResult = json_decode($response->EmptyHoursResult);
         if ($emptyHoursResult !== 1) {
-            \Log::error('Something went wrong while writing the data to VESTA.', [
+            Log::error('Something went wrong while writing the data to VESTA.', [
                 'response' => var_export($response, true),
             ]);
 


### PR DESCRIPTION
No new tests created
No tests run!

response from vesta:
```
{
   "message":"May 22 13:00:21 qa-web-002 openingsuren: http://openingsurenqa.gentgrp.gent.be|1526986821|laravel|info|127.0.0.1|http://openingsurenqa.gentgrp.gent.be||0||Received response from EmptyHours: stdClass::__set_state(array( 'EmptyHoursResult' => true, ))",
   "@version":"1",
   "@timestamp":"2018-05-22T11:00:26.889Z",
   "type":"digipolis-drupal",
   "file":"/var/log/digipolis-drupal.log",
   "host":"qa-web-002.digipolis",
   "offset":"10048572765",
   "syslog_timestamp":"May 22 13:00:21",
   "syslog_hostname":"qa-web-002",
   "syslog_program":"openingsuren",
   "base_url":"http://openingsurenqa.gentgrp.gent.be",
   "timestamp":"1526986821",
   "drupal_type":"laravel",
   "severity":"info",
   "drupal_ip":"127.0.0.1",
   "request":"http://openingsurenqa.gentgrp.gent.be",
   "drupal_uid":"0",
   "drupal_message":"Received response from EmptyHours: stdClass::__set_state(array( 'EmptyHoursResult' => true, ))",
   "account":"openingsuren",
   "application":"openingsuren",
   "environment":"qa"
}
```