### PR TITLE
Fix priorities are implemented as rankings.

### DIFF
--- a/app/Models/Ical.php
+++ b/app/Models/Ical.php
@@ -234,11 +234,16 @@ class Ical
 
             $eventPriorities = $priorities[$dtStart->toDateString()];
 
-            if (count($eventPriorities) > 1 && max($eventPriorities) == $event->priority) {
+            // This is a weird implementation/naming convention. Priorities are
+            // actually implemented as rankings. This means the *lower* the
+            // priority (read: ranking position) the more important it is
+            // (read: the higher the priority actually is).
+            if (count($eventPriorities) > 1 && min($eventPriorities) != $event->priority) {
                 continue;
             }
 
-            // Undefined index occurs when the last event of the previous month continues past midngiht into the current month.
+            // Undefined index occurs when the last event of the previous month
+            // continues past midnight into the current month.
             if (!isset($data[$dtStart->toDateString()])) {
                 continue;
             }


### PR DESCRIPTION
Tests haven't passed in ages, and to be frank (no offence, Frank), don't really test anything, so I'm not going to bother with them.

This fixes a bug where the calendar widget on https://visit.gent.be/nl/zien-doen/smak-hedendaage-kunst-gent should say 'closed' for 25 and 26/12/2018, but doesn't.