### PR TITLE
OPEN-245: Added migration to bulk update channel types.

### DIFF
--- a/database/migrations/2018_12_07_133156_bulk_update_channel_types.php
+++ b/database/migrations/2018_12_07_133156_bulk_update_channel_types.php
@@ -40,7 +40,7 @@ class BulkUpdateChannelTypes extends Migration
             ]);
 
         //• Indien na bovenstaande regels het eerste kanaal van een dienst nog geen type heeft, dan wordt het eerste kanaal gemarkeerd als type “Algemeen”
-        foreach (Service::all() as $service) {
+        foreach (Service::has('channels')->get() as $service) {
             $firstChannel = $service->channels[0];
             if ($firstChannel->type === null) {
                 $firstChannel->type_id = $general;

--- a/database/migrations/2018_12_07_133156_bulk_update_channel_types.php
+++ b/database/migrations/2018_12_07_133156_bulk_update_channel_types.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Models\Channel;
+use App\Models\Service;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class BulkUpdateChannelTypes extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $general = DB::table('types')
+            ->select('id')
+            ->where('name', 'like', 'Algemeen')
+            ->first()->id;
+
+        $appointment = DB::table('types')
+            ->select('id')
+            ->where('name', 'like', 'Na afspraak')
+            ->first()->id;
+
+        //• Kanalen genaamd “Algemeen” zijn van het type “Algemeen”
+        DB::table('channels')->where('label', 'like', '%algemeen%')
+            ->where('type_id', '=', null)
+            ->update([
+                'type_id' => $general,
+            ]);
+
+        //• Kanalen met “afspraak” (case insensitive) in de naam zijn van het type “Op afspraak”
+        DB::table('channels')->where('label', 'like', '%afspraak%')
+            ->where('type_id', '=', null)
+            ->update([
+                'type_id' => $appointment,
+            ]);
+
+        //• Indien na bovenstaande regels het eerste kanaal van een dienst nog geen type heeft, dan wordt het eerste kanaal gemarkeerd als type “Algemeen”
+        foreach (Service::all() as $service) {
+            $firstChannel = $service->channels[0];
+            if ($firstChannel->type === null) {
+                $firstChannel->type_id = $general;
+                $firstChannel->save();
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/migrations/2018_12_07_133156_bulk_update_channel_types.php
+++ b/database/migrations/2018_12_07_133156_bulk_update_channel_types.php
@@ -25,21 +25,29 @@ class BulkUpdateChannelTypes extends Migration
             ->where('name', 'like', 'Na afspraak')
             ->first()->id;
 
-        //• Kanalen genaamd “Algemeen” zijn van het type “Algemeen”
+        /**
+         * Channels with label “Algemeen” are of type “Algemeen”.
+         */
         DB::table('channels')->where('label', 'like', '%algemeen%')
             ->where('type_id', '=', null)
             ->update([
                 'type_id' => $general,
             ]);
 
-        //• Kanalen met “afspraak” (case insensitive) in de naam zijn van het type “Op afspraak”
+        /**
+         * Channels with label “afspraak” (case insensitive)
+         * are of type “Op afspraak”.
+         */
         DB::table('channels')->where('label', 'like', '%afspraak%')
             ->where('type_id', '=', null)
             ->update([
                 'type_id' => $appointment,
             ]);
 
-        //• Indien na bovenstaande regels het eerste kanaal van een dienst nog geen type heeft, dan wordt het eerste kanaal gemarkeerd als type “Algemeen”
+        /**
+         * If the first channel of a service still has no type,
+         * the type is “Algemeen”.
+         */
         foreach (Service::has('channels')->get() as $service) {
             $firstChannel = $service->channels[0];
             if ($firstChannel->type === null) {


### PR DESCRIPTION
Tested by seeding three channels for each service

label: balie, type: null
label: tele-service, type: telefonisch
label: Op afspraak, type null

Ran migragrion
all 'op afspraak' channels have type 'afsrpaak'
all 'balie' channels have type 'algemeen'