### PR TITLE
HEAT-6168212: Normalize events before generating vesta output.

### DIFF
--- a/app/Jobs/UpdateVestaOpeninghours.php
+++ b/app/Jobs/UpdateVestaOpeninghours.php
@@ -85,7 +85,13 @@ class UpdateVestaOpeninghours extends BaseJob implements ShouldQueue
             $output = $recurringOHService->getServiceOutput($service, $startDate, $endDate);
 
             if ($output === '') {
-                throw new \Exception('No data was found to send to VESTA.', 1);
+                $vService = app(VestaService::class);
+                $vService->setClient();
+                $synced = $vService->emptyOpeninghours($service->identifier);
+                if (!$synced) {
+                    $this->letsFail('Not able to send the data to VESTA.');
+                    return;
+                }
             }
             $this->sendToVesta($service, $output);
         } catch (\Exception $ex) {

--- a/app/Services/RecurringOHService.php
+++ b/app/Services/RecurringOHService.php
@@ -274,7 +274,7 @@ class RecurringOHService
             // date of 2018-05-01 17:00:00, but have an 'until' value of
             // 2020-12-31. This would represent all 1sts of May for years 2018,
             // 2019 and 2020. We need to get the event that lies within our
-            // and end date filters.
+            // start and end date filters.
 
             $difference = $eventEnd->year - $eventStart->year;
             $eventStart->year = $startDate->year;

--- a/app/Services/RecurringOHService.php
+++ b/app/Services/RecurringOHService.php
@@ -94,6 +94,7 @@ class RecurringOHService
         ];
 
         foreach ($calendar->events as $event) {
+            $this->normalizeEvent($event, $startDate, $endDate);
             $isValid = $this->validateEvent($event, $startDate, $endDate);
 
             if ($isValid) {
@@ -260,6 +261,32 @@ class RecurringOHService
         return $properties;
     }
 
+    public function normalizeEvent(Event $event, Carbon $startDate, Carbon $endDate)
+    {
+        $eventStart = new Carbon($event->start_date);
+        $eventEnd = new Carbon($event->end_date);
+
+        $frequency = $this->getFrequency($event);
+
+        if ($frequency == self::YEARLY) {
+            // Normalize start and end date:
+            // An event can have a start date of 2018-05-01 09:00:00 and an end
+            // date of 2018-05-01 17:00:00, but have an 'until' value of
+            // 2020-12-31. This would represent all 1sts of May for years 2018,
+            // 2019 and 2020. We need to get the event that lies within our
+            // and end date filters.
+
+            $difference = $eventEnd->year - $eventStart->year;
+            $eventStart->year = $startDate->year;
+            while ($eventStart->lessThan($startDate)) {
+                $eventStart->year++;
+            }
+            $eventEnd->year = $eventStart->year;
+            $eventEnd->addYears($difference);
+            $event->start_date = $eventStart->format('Y-m-d H:i:s');
+            $event->end_date = $eventEnd->format('Y-m-d H:i:s');
+        }
+    }
 
     /**
      * @param Event $event

--- a/tests/jobs/UpdateVestaOpeninghoursTest.php
+++ b/tests/jobs/UpdateVestaOpeninghoursTest.php
@@ -63,7 +63,7 @@ class UpdateVestaOpeninghoursTest extends \TestCase
      * @test
      * @group validation
      */
-    public function testFailOnEmptyService()
+    public function testRemoveOnEmptyService()
     {
         $this->app->singleton(RecurringOHService::class, function () {
             $mock = $this->createMock(\App\Services\RecurringOHService::class, ['getServiceOutput']);
@@ -73,15 +73,19 @@ class UpdateVestaOpeninghoursTest extends \TestCase
 
             return $mock;
         });
-        $service = factory(Service::class)->create(['identifier' => 'JyeehBaby', 'source' => 'vesta']);
-        $this->setExpectedException(
-            \Exception::class,
-            'The App\Jobs\UpdateVestaOpeninghours job failed for App\Models\Service (' . $service->id .
-            '). Check the logs for details. - No data was found to send to VEST'
-        );
-        $job = new UpdateVestaOpeninghours($service->identifier, $service->id, true);
+        $this->app->singleton(VestaService::class, function () {
+            $mock = $this->createMock(\App\Services\VestaService::class, ['updateOpeninghours']);
+            $mock->expects($this->atLeastOnce())
+                ->method('emptyOpeninghours')
+                ->willReturn(true);
 
-        $queue = dispatch($job);
+            return $mock;
+        });
+
+        $service = factory(Service::class)->create(['identifier' => 'JyeehBaby', 'source' => 'vesta']);
+        $job = new UpdateVestaOpeninghours($service->identifier, $service->id, true);
+        $job->handle();
+        $this->assertTrue(true);
     }
 
     /**


### PR DESCRIPTION
Bug report:
```
Er is  iets vreemd is misschien een bug.

 

Gisteren kreeg ik de melding dat bij Hotel  Clemmen stond dat het gesloten is op dinsdag 1 mei 2018.

Als ik ging kijken  in de module stond er bij jaarlijks  inderdaad geldig vanaf  2018-05-01 tot  2020-12-31.

Ik heb  dat dan op 2019 gezet ( zie  printscreen hieronder want er was de vraag om het goed te zetten en nu staat deze al goed op de site

 

Een datum van 2018 zou hij niet meer op de site mogen tonen
```

Before:

```
$ php artisan openinghours:print-vesta-output 2367 
<h4>Algemeen</h4>
<div>
<p>maandag tot en met vrijdag: van 7 tot 19 uur<br />
zaterdag: van 10 tot 12.15 uur en van 12.30 tot 17 uur</p>
</div>
<div>
<h4>Sluitingsdag</h4>
<p>zondag: gesloten</p>
</div>
<div>
<h4>Eerstvolgende feest- en brugdagen</h4>
<p>dinsdag 1 mei 2018: gesloten<br />
maandag 22 april 2019: gesloten<br />
donderdag 30 mei 2019: gesloten<br />
maandag 10 juni 2019: gesloten</p>
</div>
```
After:
```
$ php artisan openinghours:print-vesta-output 2367 
<h4>Algemeen</h4>
<div>
<p>maandag tot en met vrijdag: van 7 tot 19 uur<br />
zaterdag: van 10 tot 12.15 uur en van 12.30 tot 17 uur</p>
</div>
<div>
<h4>Sluitingsdag</h4>
<p>zondag: gesloten</p>
</div>
<div>
<h4>Eerstvolgende feest- en brugdagen</h4>
<p>maandag 22 april 2019: gesloten<br />
woensdag 1 mei 2019: gesloten<br />
donderdag 30 mei 2019: gesloten<br />
maandag 10 juni 2019: gesloten</p>
</div>
```
