### PR TITLE
HEAT-6217821: Use the RRule class in RecurringOHService::validateEvent

### DIFF
--- a/app/Services/RecurringOHService.php
+++ b/app/Services/RecurringOHService.php
@@ -248,7 +248,7 @@ class RecurringOHService
     /**
      * Split the RRule up into props
      *
-     * @param $rrime
+     * @param $rrule
      * @return mixed
      */
     public function getRuleProperties($rrule)
@@ -307,49 +307,45 @@ class RecurringOHService
             return false;
         }
 
-        $eventStartHour = new Carbon($event->start_date);
-        $eventEndHour = new Carbon($event->end_date);
+        $eventStartDate = new Carbon($event->start_date);
         $eventUntilDate = new Carbon($event->until);
+        $openingHoursStartDate = new Carbon($event->calendar->openinghours->start_date);
+        $openingHoursEndDate = new Carbon($event->calendar->openinghours->end_date);
 
-        // check event until > begin of periode to skip
-        if ($eventUntilDate->lessThan($startDate)) {
-            return false;
-        }
+        // Compact the period to the latest start date and earliest end date so
+        // we have the smallest possible period in which this event is valid.
+        $startDates = [
+            $startDate,
+            $eventStartDate,
+            $openingHoursStartDate,
+        ];
+        $endDates = [
+            $endDate,
+            $eventUntilDate,
+            $openingHoursEndDate,
+        ];
+        sort($startDates);
+        sort($endDates);
 
-        // check event start is later then end of periode to skip
-        if ($eventStartHour->greaterThan($endDate)) {
+        $periodStart = end($startDates);
+        $periodEnd = reset($endDates);
+
+        // Check if we have a valid period.
+        if ($periodStart->greaterThan($periodEnd)) {
             return false;
         }
 
         if (strpos($event->rrule, 'FREQ=YEARLY') !== false) {
-            $difference = $eventEndHour->year - $eventStartHour->year;
-
-            // take the year of the startDate
-            $eventStartHour->year = $startDate->year;
-            $eventEndHour->year = $startDate->year;
-
-            $eventEndHour->addYears($difference);
-
-            // the end could be in the next year for example Christmas Holidays
-            if ($eventEndHour->greaterThan($startDate) && $eventStartHour->lessThan($endDate)) {
-                return true;
+            $eventStartDate->year = $periodStart->year;
+            if ($eventStartDate->lessThan($periodStart)) {
+                $eventStartDate->year++;
             }
-
-            // check on year leap (needed for when request if from December until February you have a 2nd new year to check)
-            if ($startDate->year != $endDate->year) {
-                $eventStartHour->year = $endDate->year;
-                $eventEndHour->year = $endDate->year;
-
-                // the end could be in the next year
-                $eventEndHour->addYears($difference);
-                if ($eventEndHour->greaterThan($startDate) && $eventStartHour->lessThan($endDate)) {
-                    return true;
-                }
-
+            $rruleString = 'RRULE:' . $event->rrule . ';UNTIL=' . $eventUntilDate->format('Ymd\THis')
+                . PHP_EOL . 'DTSTART:' . $eventStartDate->format('Ymd\THis');
+            $rrule = new \RRule\RRule($rruleString);
+            if (!$rrule->getOccurrencesBetween($startDate, $endDate)) {
                 return false;
             }
-
-            return false;
         }
 
         return true;

--- a/tests/services/RecurringOHServiceTest.php
+++ b/tests/services/RecurringOHServiceTest.php
@@ -254,6 +254,9 @@ EOL;
         ]);
 
         $event->calendar = new Calendar();
+        $event->calendar->openinghours = new Openinghours();
+        $event->calendar->openinghours->start_date = '2015-01-01';
+        $event->calendar->openinghours->end_date = '2099-11-31';
 
         $valid = $this->recurringOHService->validateEvent($event, $startDate, $endDate);
         $this->assertTrue($valid);


### PR DESCRIPTION
The RecurringOHService::validateEvent method now uses the \RRule\RRule
class to check if there are occurrences of the given event between two
dates (instead of reinventing the wheel with our own implementation).
These two dates are calculated so that we have the smallest possible
period in which this event is valid. The calculation goes as follows:
  - Take the three possible start dates:
    - Start date given as parameter to this method
    - Start date of the event (first occurence)
    - Start date of the openinghours of this event
  - Take the three possible end dates:
    - End date given as parameter to this method
    - Until date of the event
    - End date of the openinghours of this event
  - Of these dates, take the largest start date and the smallest end
  date
  - Validate that the resulting start date is smaller than the resulting
  end date (if not, there is no occurrence of this event in the given
  period)
  - Validate that the event occurs in the resulting period, using the
  \RRule\RRule class